### PR TITLE
fix: correct typo 'succesfully' -> 'successfully' in JSDoc comments

### DIFF
--- a/src/captcha.ts
+++ b/src/captcha.ts
@@ -52,7 +52,7 @@ export class WidgetInstance {
   private e!: HTMLElement & { friendlyChallengeWidget?: WidgetInstance };
 
   /**
-   * The captcha has been succesfully solved.
+   * The captcha has been successfully solved.
    */
   public valid = false;
   private opts: WidgetInstanceOptions;
@@ -285,7 +285,7 @@ export class WidgetInstance {
   }
 
   /**
-   * This is to be called when the puzzle has been succesfully completed.
+   * This is to be called when the puzzle has been successfully completed.
    * Here the hidden field gets updated with the solution.
    * @param data message from the webworker
    */


### PR DESCRIPTION
## Summary
Fix typo `succesfully` → `successfully` in JSDoc comments in `src/captcha.ts`:

- Line 55: `* The captcha has been succesfully solved.` → `* The captcha has been successfully solved.`
- Line 288: `* This is to be called when the puzzle has been succesfully completed.` → `* This is to be called when the puzzle has been successfully completed.`

Minimal fix: 1 file, 2 line changes.