### PR TITLE
Tweak French localization

### DIFF
--- a/src/localization.ts
+++ b/src/localization.ts
@@ -60,7 +60,7 @@ const LANG_FR: Localization = {
   text_init: "Chargement...",
 
   text_ready: "Vérification Anti-Robot",
-  button_start: "Clique ici pour vérifier",
+  button_start: "Cliquez ici pour vérifier",
 
   text_fetching: "Chargement du défi",
 


### PR DESCRIPTION
Previously changed the other direction [here](https://github.com/FriendlyCaptcha/friendly-challenge/commit/28b58f616212ea256400918e7f1e72eae32707e0). But apparently `Cliquez` is more polite!